### PR TITLE
Standardize workflow name

### DIFF
--- a/project.ts
+++ b/project.ts
@@ -1,5 +1,5 @@
 import { Project } from "slack-cloud-sdk/mod.ts";
-import { NewProjectShortcut } from "./triggers/new_channel_shortcut.ts";
+import { NewProjectShortcut } from "./triggers/new_project_shortcut.ts";
 
 Project({
   name: "Project Organizer",

--- a/triggers/new_project_shortcut.ts
+++ b/triggers/new_project_shortcut.ts
@@ -1,7 +1,7 @@
 import { DefineTrigger, TriggerTypes } from "slack-cloud-sdk/mod.ts";
 import { NewProjWorkflow } from "../workflows/project_wf.ts";
 
-export const NewProjectShortcut = DefineTrigger("reverse_echo_shortcut", {
+export const NewProjectShortcut = DefineTrigger("new_project_shortcut", {
   type: TriggerTypes.MessageShortcut,
   name: "New Project channel",
   description: "Create a new channel for your project",

--- a/workflows/project_wf.ts
+++ b/workflows/project_wf.ts
@@ -1,6 +1,6 @@
 import { DefineWorkflow, Schema } from "slack-cloud-sdk/mod.ts";
 
-export const NewProjWorkflow = DefineWorkflow("new_channel", {
+export const NewProjWorkflow = DefineWorkflow("new_project", {
   title: "Create new project",
   description: "Create a new project channel from a message.",
   input_parameters: {


### PR DESCRIPTION
###  Summary

- Standardizes verbiage from `new_channel_shortcut` to `new_project_shortcut`
- Fixes copypasta from `reverse_echo_shortcut`

Tested by using this new template via `slack create -t frankeld/deno-built-in-functions`


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/future-built-in-functions/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).